### PR TITLE
Add option to set Encoding

### DIFF
--- a/credentials/FirebirdApi.credentials.ts
+++ b/credentials/FirebirdApi.credentials.ts
@@ -72,5 +72,11 @@ export class FirebirdApi implements ICredentialType {
 			default: false,
 			description: 'Set to true to lowercase keys.',
 		},
+		{
+			displayName: 'Encoding',
+			name: 'encoding',
+			type: 'string',
+			default: 'UTF8',
+		},
 	];
 }


### PR DESCRIPTION
First, thanks for making this node, I can't believe n8n does not include it by default.
Second, this PR is a suggestion to please add support for changing charset/encoding on the connection parameters. This is required by some international users for avoiding some errors.